### PR TITLE
Fixed error handling if download fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,4 +166,4 @@ const child_process = require('child_process'),
 getTags(1).catch((err) => {
 	console.error(err);
 	process.exit(1);
-})
+});

--- a/index.js
+++ b/index.js
@@ -162,10 +162,8 @@ const child_process = require('child_process'),
 		});
 	}
 
-	
-try{
-	getTags(1);
-} catch(err){
+
+getTags(1).catch((err) => {
 	console.error(err);
 	process.exit(1);
-}
+})


### PR DESCRIPTION
`getTags(1)` is called outside of `async` function so `try`-`catch` does not catch errors. We have to use `Promise.catch` instead.